### PR TITLE
Add text wrapping

### DIFF
--- a/src/ui/format/index.ts
+++ b/src/ui/format/index.ts
@@ -1,0 +1,1 @@
+export * from "./wrapped-text";

--- a/src/ui/format/wrapped-text.ts
+++ b/src/ui/format/wrapped-text.ts
@@ -1,0 +1,31 @@
+export const formatWrappedText = (
+  input: string,
+  width: number = 79
+): string[] => {
+  const result: string[] = [];
+
+  input.split(/\r?\n/).forEach((inputLine) => {
+    if (/^\s*$/.test(inputLine)) {
+      result.push("");
+    } else {
+      let outputLine = "";
+
+      inputLine.split(" ").forEach((word) => {
+        if (outputLine.length + word.length <= width) {
+          if (outputLine.length > 0) {
+            outputLine += " ";
+          }
+          outputLine += word;
+        } else {
+          result.push(outputLine);
+          outputLine = word;
+        }
+      });
+      if (outputLine.length > 0) {
+        result.push(outputLine);
+      }
+    }
+  });
+
+  return result;
+};

--- a/src/ui/submission.ts
+++ b/src/ui/submission.ts
@@ -4,7 +4,7 @@ import { isEmpty } from "lodash";
 import { Submission } from "snoowrap";
 import { Writable } from "stream";
 
-import { renderTimestamp } from "./util";
+import { renderTimestamp, renderWrappedText } from "./util";
 
 type RenderSubmissionOptions = {
   displaySelfText: boolean;
@@ -34,9 +34,11 @@ export const renderSubmission = (
     )}${chalk.yellow(")")}\n`
   );
   output.write(columnify(info, { showHeaders: false }));
-  output.write(`\n\n    ${submission.title}\n`);
+  output.write("\n\n");
+  renderWrappedText(output, submission.title, 79, 4);
   if (options.displaySelfText && !isEmpty(submission.selftext)) {
-    output.write(`\n    ${submission.selftext}\n`);
+    output.write("\n");
+    renderWrappedText(output, submission.selftext, 79, 4);
   }
 };
 

--- a/src/ui/util.ts
+++ b/src/ui/util.ts
@@ -1,2 +1,16 @@
+import { Writable } from "stream";
+
+import { formatWrappedText } from "./format";
+
+export const renderWrappedText = (
+  output: Writable,
+  input: string,
+  width: number = 79,
+  padding: number = 0
+) =>
+  formatWrappedText(input, width - padding).forEach((line) =>
+    output.write(`${" ".repeat(padding)}${line}\n`)
+  );
+
 export const renderTimestamp = (timestamp: number) =>
   new Date(timestamp * 1000).toString();


### PR DESCRIPTION
Wrap long lines in submission titles and texts into maximum of 79
columns for better readability.